### PR TITLE
syntax fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "drupal/semanticviews": "^2.2",
     "drupal/views_data_export": "^1.0@alpha",
     "drupal/views_field_view": "^1.0@beta",
-    "phpoffice/phpexcel": "1.7",
+    "phpoffice/phpexcel": "^1.7"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,


### PR DESCRIPTION
1. The comma was trailing and invalidated the file.

2. The version format was wrong and causes composer to crash.